### PR TITLE
refactor: abstract outline rendering

### DIFF
--- a/packages/scan/src/index.ts
+++ b/packages/scan/src/index.ts
@@ -1,5 +1,6 @@
-import { init } from './install-hook'; // Initialize RDT hook
+import { init } from "./install-hook"; // Initialize RDT hook
 
 init();
 
-export * from './core/index';
+export * from "./core/index";
+export * from "./new-outlines/outline-renderer";

--- a/packages/scan/src/new-outlines/offscreen-canvas.worker.ts
+++ b/packages/scan/src/new-outlines/offscreen-canvas.worker.ts
@@ -1,5 +1,5 @@
-import { OUTLINE_ARRAY_SIZE, drawCanvas, initCanvas } from './canvas';
-import type { ActiveOutline } from './types';
+import { OUTLINE_ARRAY_SIZE, drawCanvas, initCanvas } from "./canvas";
+import type { ActiveOutline } from "./types";
 
 let canvas: OffscreenCanvas | null = null;
 let ctx: OffscreenCanvasRenderingContext2D | null = null;
@@ -23,7 +23,7 @@ const draw = () => {
 self.onmessage = (event) => {
   const { type } = event.data;
 
-  if (type === 'init') {
+  if (type === "init") {
     canvas = event.data.canvas;
     dpr = event.data.dpr;
 
@@ -36,7 +36,7 @@ self.onmessage = (event) => {
 
   if (!canvas || !ctx) return;
 
-  if (type === 'resize') {
+  if (type === "resize") {
     dpr = event.data.dpr;
     canvas.width = event.data.width * dpr;
     canvas.height = event.data.height * dpr;
@@ -47,8 +47,9 @@ self.onmessage = (event) => {
     return;
   }
 
-  if (type === 'draw-outlines') {
+  if (type === "draw-outlines") {
     const { data, names } = event.data;
+    const now = performance.now();
 
     const sharedView = new Float32Array(data);
     for (let i = 0; i < sharedView.length; i += OUTLINE_ARRAY_SIZE) {
@@ -66,7 +67,7 @@ self.onmessage = (event) => {
         y,
         width,
         height,
-        frame: 0,
+        startTime: now,
         targetX: x,
         targetY: y,
         targetWidth: width,
@@ -78,7 +79,7 @@ self.onmessage = (event) => {
       const existingOutline = activeOutlines.get(key);
       if (existingOutline) {
         existingOutline.count++;
-        existingOutline.frame = 0;
+        existingOutline.startTime = now;
         existingOutline.targetX = x;
         existingOutline.targetY = y;
         existingOutline.targetWidth = width;
@@ -96,7 +97,7 @@ self.onmessage = (event) => {
     return;
   }
 
-  if (type === 'scroll') {
+  if (type === "scroll") {
     const { deltaX, deltaY } = event.data;
     for (const outline of activeOutlines.values()) {
       const newX = outline.x - deltaX;

--- a/packages/scan/src/new-outlines/outline-renderer.ts
+++ b/packages/scan/src/new-outlines/outline-renderer.ts
@@ -50,8 +50,8 @@ export class CanvasOutlineRenderer implements OutlineRenderer {
   dispose(): void {}
 
   private setCanvasSize(size: Size) {
-    this.canvas.style.width = `{size.width}px`;
-    this.canvas.style.height = `{size.height}px`;
+    this.canvas.style.width = `${size.width}px`;
+    this.canvas.style.height = `${size.height}px`;
     this.canvas.width = size.width * this.dpr;
     this.canvas.height = size.height * this.dpr;
     if (this.ctx) {

--- a/packages/scan/src/new-outlines/outline-renderer.ts
+++ b/packages/scan/src/new-outlines/outline-renderer.ts
@@ -1,0 +1,214 @@
+import { Size } from "~web/widget/types";
+import { drawCanvas, updateScroll } from "./canvas";
+import { ActiveOutline, OutlineData } from "./types";
+
+export interface OutlineRenderer {
+  renderOutlines(outlines: OutlineData[]): void;
+  resize(size: Size): void;
+  scroll(deltaX: number, deltaY: number): void;
+}
+
+export class CanvasOutlineRenderer implements OutlineRenderer {
+  private activeOutlines: Map<string, ActiveOutline> = new Map();
+  private animationFrameId: ReturnType<typeof requestAnimationFrame> | null =
+    null;
+  private ctx: CanvasRenderingContext2D | null;
+  private isResizeScheduled = false;
+
+  constructor(
+    private canvas: HTMLCanvasElement,
+    private size: Size,
+    private dpr: number,
+  ) {
+    this.ctx = canvas.getContext("2d", { alpha: true });
+    this.setCanvasSize(size);
+  }
+
+  scroll(deltaX: number, deltaY: number): void {
+    updateScroll(this.activeOutlines, deltaX, deltaY);
+  }
+
+  resize(size: Size): void {
+    this.size = size;
+    if (this.isResizeScheduled) return;
+    this.isResizeScheduled = true;
+    setTimeout(() => {
+      this.setCanvasSize(this.size);
+      this.draw();
+      this.isResizeScheduled = false;
+    });
+  }
+
+  renderOutlines(outlines: OutlineData[]): void {
+    this.updateOutlines(outlines);
+    if (!this.animationFrameId) {
+      this.animationFrameId = requestAnimationFrame(this.draw);
+    }
+  }
+
+  private setCanvasSize(size: Size) {
+    this.canvas.style.width = `{size.width}px`;
+    this.canvas.style.height = `{size.height}px`;
+    this.canvas.width = size.width * this.dpr;
+    this.canvas.height = size.height * this.dpr;
+    if (this.ctx) {
+      this.ctx.resetTransform();
+      this.ctx.scale(this.dpr, this.dpr);
+    }
+  }
+
+  private updateOutlines(outlines: OutlineData[]) {
+    for (const {
+      id,
+      name,
+      count,
+      x,
+      y,
+      width,
+      height,
+      didCommit,
+    } of outlines) {
+      const outline: ActiveOutline = {
+        id,
+        name,
+        count,
+        x,
+        y,
+        width,
+        height,
+        frame: 0,
+        targetX: x,
+        targetY: y,
+        targetWidth: width,
+        targetHeight: height,
+        didCommit,
+      };
+      const key = String(outline.id);
+
+      const existingOutline = this.activeOutlines.get(key);
+      if (existingOutline) {
+        existingOutline.count++;
+        existingOutline.frame = 0;
+        existingOutline.targetX = x;
+        existingOutline.targetY = y;
+        existingOutline.targetWidth = width;
+        existingOutline.targetHeight = height;
+        existingOutline.didCommit = didCommit;
+      } else {
+        this.activeOutlines.set(key, outline);
+      }
+    }
+  }
+
+  private draw = () => {
+    if (!this.ctx || !this.canvas) {
+      return;
+    }
+
+    const shouldContinue = drawCanvas(
+      this.ctx,
+      this.canvas,
+      this.dpr,
+      this.activeOutlines,
+    );
+
+    if (shouldContinue) {
+      this.animationFrameId = requestAnimationFrame(this.draw);
+    } else {
+      this.animationFrameId = null;
+    }
+  };
+}
+
+// The worker code will be replaced at build time
+const workerCode = "__WORKER_CODE__";
+const OUTLINE_ARRAY_SIZE = 7;
+const SupportedArrayBuffer =
+  typeof SharedArrayBuffer !== "undefined" ? SharedArrayBuffer : ArrayBuffer;
+
+export class WorkerOutlineRenderer implements OutlineRenderer {
+  private worker: Worker;
+  private isResizeScheduled = false;
+
+  constructor(
+    private canvasEl: HTMLCanvasElement,
+    private size: Size,
+    private dpr: number,
+  ) {
+    this.worker = new Worker(
+      URL.createObjectURL(
+        new Blob([workerCode], { type: "application/javascript" }),
+      ),
+    );
+
+    this.setCanvasSize(size);
+
+    const offscreenCanvas = canvasEl.transferControlToOffscreen();
+    this.worker.postMessage(
+      {
+        type: "init",
+        canvas: offscreenCanvas,
+        width: size.width * dpr,
+        height: size.height * dpr,
+        dpr,
+      },
+      [offscreenCanvas],
+    );
+  }
+
+  private setCanvasSize(size: Size) {
+    this.canvasEl.style.width = `${size.width}px`;
+    this.canvasEl.style.height = `${size.height}px`;
+  }
+
+  renderOutlines(outlines: OutlineData[]): void {
+    const arrayBuffer = new SupportedArrayBuffer(
+      outlines.length * OUTLINE_ARRAY_SIZE * 4,
+    );
+    const sharedView = new Float32Array(arrayBuffer);
+    const outlineNames = new Array(outlines.length);
+
+    outlines.forEach((outline, i) => {
+      const { id, name, count, x, y, width, height, didCommit } = outline;
+      const scaledIndex = i * OUTLINE_ARRAY_SIZE;
+      sharedView[scaledIndex] = id;
+      sharedView[scaledIndex + 1] = count;
+      sharedView[scaledIndex + 2] = x;
+      sharedView[scaledIndex + 3] = y;
+      sharedView[scaledIndex + 4] = width;
+      sharedView[scaledIndex + 5] = height;
+      sharedView[scaledIndex + 6] = didCommit;
+      outlineNames[i] = name;
+    });
+
+    this.worker.postMessage({
+      type: "draw-outlines",
+      data: arrayBuffer,
+      names: outlineNames,
+    });
+  }
+
+  resize(size: Size): void {
+    this.size = size;
+    if (this.isResizeScheduled) return;
+    this.isResizeScheduled = true;
+    setTimeout(() => {
+      this.setCanvasSize(this.size);
+      this.worker.postMessage({
+        type: "resize",
+        width: this.size.width,
+        height: this.size.height,
+        dpr: this.dpr,
+      });
+      this.isResizeScheduled = false;
+    });
+  }
+
+  scroll(deltaX: number, deltaY: number): void {
+    this.worker.postMessage({
+      type: "scroll",
+      deltaX,
+      deltaY,
+    });
+  }
+}

--- a/packages/scan/src/new-outlines/outline-renderer.ts
+++ b/packages/scan/src/new-outlines/outline-renderer.ts
@@ -6,6 +6,7 @@ export interface OutlineRenderer {
   renderOutlines(outlines: OutlineData[]): void;
   resize(size: Size): void;
   scroll(deltaX: number, deltaY: number): void;
+  dispose(): void;
 }
 
 export class CanvasOutlineRenderer implements OutlineRenderer {
@@ -45,6 +46,8 @@ export class CanvasOutlineRenderer implements OutlineRenderer {
       this.animationFrameId = requestAnimationFrame(this.draw);
     }
   }
+
+  dispose(): void {}
 
   private setCanvasSize(size: Size) {
     this.canvas.style.width = `{size.width}px`;
@@ -154,6 +157,10 @@ export class WorkerOutlineRenderer implements OutlineRenderer {
       },
       [offscreenCanvas],
     );
+  }
+
+  dispose(): void {
+    this.worker.terminate();
   }
 
   private setCanvasSize(size: Size) {

--- a/packages/scan/src/new-outlines/outline-renderer.ts
+++ b/packages/scan/src/new-outlines/outline-renderer.ts
@@ -61,6 +61,7 @@ export class CanvasOutlineRenderer implements OutlineRenderer {
   }
 
   private updateOutlines(outlines: OutlineData[]) {
+    const now = performance.now();
     for (const {
       id,
       name,
@@ -79,7 +80,7 @@ export class CanvasOutlineRenderer implements OutlineRenderer {
         y,
         width,
         height,
-        frame: 0,
+        startTime: now,
         targetX: x,
         targetY: y,
         targetWidth: width,
@@ -91,7 +92,7 @@ export class CanvasOutlineRenderer implements OutlineRenderer {
       const existingOutline = this.activeOutlines.get(key);
       if (existingOutline) {
         existingOutline.count++;
-        existingOutline.frame = 0;
+        existingOutline.startTime = now;
         existingOutline.targetX = x;
         existingOutline.targetY = y;
         existingOutline.targetWidth = width;

--- a/packages/scan/src/new-outlines/types.ts
+++ b/packages/scan/src/new-outlines/types.ts
@@ -52,7 +52,7 @@ export interface ActiveOutline {
   targetY: number;
   targetWidth: number;
   targetHeight: number;
-  frame: number;
+  startTime: number;
   didCommit: 1 | 0;
 }
 


### PR DESCRIPTION
Moves `canvas`-related code out of `new-outlines/index.ts` and abstracts the canvas operations with an `OutlineRenderer` interface.